### PR TITLE
Remove dead assets and improve NSDateFormatter usage

### DIFF
--- a/TheWidget/TodayViewController.swift
+++ b/TheWidget/TodayViewController.swift
@@ -24,7 +24,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     var tz2Selection: String!
     var tz3Selection: String!
     var tz4Selection: String!
-    
+    let formatter = NSDateFormatter()
+
     let defaults = NSUserDefaults(suiteName: "group.com.mikjonsson.TZWidget")
   
     
@@ -101,8 +102,6 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         tzName3.text = tz3Selection.location()
         tzName4.text = tz4Selection.location()
         
-        
-        let formatter = NSDateFormatter()
         formatter.dateFormat = "\(dateFormat)\n\(clockFormat)"
         
         formatter.timeZone = NSTimeZone(name: tz1Selection)

--- a/TimeZoneWidget/ViewController.swift
+++ b/TimeZoneWidget/ViewController.swift
@@ -29,7 +29,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     var timeZones = NSTimeZone.knownTimeZoneNames()
     let defaults = NSUserDefaults(suiteName: "group.com.mikjonsson.TZWidget")
     let screenWidth = UIScreen.mainScreen().bounds.width
-    
+    let formatter = NSDateFormatter()
+
     var isFreeApp = false // A possible way for future switch between payed and free app
     
     override func viewDidLoad() {
@@ -208,7 +209,6 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             }
         }
       
-        let formatter = NSDateFormatter()
         formatter.dateFormat = "\(dateFormat)\n\(clockFormat)"
         
         formatter.timeZone = NSTimeZone(name: selectedZones[0]!)


### PR DESCRIPTION
Please test this, NSDateFormatter can be reused.
Couldn't  build the project because of the dead assets but after removing them it built successfully.
Didn't give it a test-run though.
